### PR TITLE
Adds uglifier harmony true to production.rb in config

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,6 +1,6 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
-
+  config.assets.js_compressor = Uglifier.new(:harmony => true)
   # Code is not reloaded between requests.
   config.cache_classes = true
 


### PR DESCRIPTION
Adds config.assets.js_compressor = Uglifier.new(:harmony => true) to config/production.rb for Heroku fix on precompiling assets failed.

https://stackoverflow.com/questions/53916272/pushing-a-rails-app-to-heroku-precompiling-assets-failed

Also tried install sassc to see if it would fix

https://stackoverflow.com/questions/53235808/heroku-not-updating-getting-error-yarn-executable-was-not-detected-in-system